### PR TITLE
Gregify almost all the Delightful recipes and remove some that have GT alternatives

### DIFF
--- a/overrides/kubejs/server_scripts/Recipes/Delightful.js
+++ b/overrides/kubejs/server_scripts/Recipes/Delightful.js
@@ -157,6 +157,10 @@ ServerEvents.recipes(event => {
     })
     //Removing the stove from End's Delight. A similar one already exists in Ender's Delight
     event.remove({ output:'ends_delight:end_stove' })
+    //Added Tag to hide from REI
+    ServerEvents.tags('item', event => {
+        event.add('forge:viewers/hidden_from_recipe', 'ends_delight:end_stove')
+    })
     event.remove({ output:'endersdelight:endstone_stove' })
     event.shaped( 'endersdelight:endstone_stove', [
         'OOO',
@@ -276,6 +280,7 @@ ServerEvents.recipes(event => {
 
 //Removing some recipes that have a GT alternative
 ServerEvents.recipes(event => {
+    //We should fine more uses for bark as well as bring it back for paper recipes in the future, for now removing it is fine.
     event.remove({ id:'farmersdelight:paper_from_tree_bark' })
     event.remove({ id:'farmersdelight:painting_from_canvas' })
     event.remove({ id:'farmersdelight:book_from_canvas' })

--- a/overrides/kubejs/server_scripts/Recipes/Delightful.js
+++ b/overrides/kubejs/server_scripts/Recipes/Delightful.js
@@ -10,6 +10,7 @@ let yeet = (itemName) => {
         event.remove('forge:tools/scavenging', itemName)
     })
 }
+//Knives
 yeet('farmersdelight:flint_knife');
 yeet('farmersdelight:iron_knife');
 yeet('farmersdelight:golden_knife');
@@ -85,3 +86,197 @@ yeet('delightful:fiery_knife');
 yeet('delightful:amethyst_knife');
 yeet('delightful:lapis_lazuli_knife');
 yeet('delightful:bone_knife');
+
+//Functional Blocks, Gregified
+ServerEvents.recipes(event => { 
+    event.remove({ output:'farmersdelight:stove' })
+    event.shaped( 'farmersdelight:stove', [
+        'IGI',
+        'BHB',
+        'BCB'
+    ], {
+        I: 'gtceu:iron_plate',
+        G: 'minecraft:iron_bars',
+        B: 'gtceu:coke_oven_bricks',
+        C: 'minecraft:campfire',
+        H: '#forge:tools/hammers'
+    })
+    event.remove({ output:'farmersdelight:cooking_pot' })
+    event.shaped( 'farmersdelight:cooking_pot', [
+        'BSB',
+        'PHP',
+        'PPP'
+    ], {
+        B: 'betterend:leather_wrapped_stick',
+        S: 'minecraft:wooden_shovel',
+        P: 'gtceu:iron_plate',
+        H: '#forge:tools/hammers'
+    })
+    event.remove({ output:'farmersdelight:skillet' })
+    event.shaped( 'farmersdelight:skillet', [
+        'HPP',
+        'SPP',
+        'BSD'
+    ], {
+        P: 'gtceu:iron_plate',
+        B: 'betterend:leather_wrapped_stick',
+        S: 'gtceu:iron_screw',
+        D: '#forge:tools/screwdrivers',
+        H: '#forge:tools/hammers'
+    })
+    event.remove({ output:'farmersdelight:cutting_board' })
+    event.shaped( 'farmersdelight:cutting_board',[
+        'KS ',
+        'PP ',
+        '   '
+    ], {
+        K: '#forge:tools/knives',
+        S: '#forge:tools/mallets',
+        P: 'gtceu:wood_plate'
+    })
+    event.remove({ output:'nethersdelight:blackstone_stove' })
+    event.shaped( 'nethersdelight:blackstone_stove', [
+        'IGI',
+        'BHB',
+        'BCB'
+    ], {
+        I: 'gtceu:iron_plate',
+        G: 'minecraft:iron_bars',
+        C: 'minecraft:soul_campfire',
+        H: '#forge:tools/hammers',
+        B: 'minecraft:polished_blackstone_bricks'
+    })
+    event.remove({ output:'nethersdelight:blackstone_furnace' })
+    event.shaped( 'nethersdelight:blackstone_furnace', [
+        'BBB',
+        'FFF',
+        'BBB'
+    ], {
+        B: 'minecraft:blackstone',
+        F: 'minecraft:flint'
+    })
+    //Removing the stove from End's Delight. A similar one already exists in Ender's Delight
+    event.remove({ output:'ends_delight:end_stove' })
+    event.remove({ output:'endersdelight:endstone_stove' })
+    event.shaped( 'endersdelight:endstone_stove', [
+        'OOO',
+        'EHE',
+        'EBE'
+    ], {
+        O: 'gtceu:obsidian_plate',
+        E: 'minecraft:end_stone_bricks',
+        B: 'minecraft:dragon_breath',
+        H: '#forge:tools/hammers'
+    })
+})
+
+//Cabinets, starting with the cabinet function
+ServerEvents.recipes(event => {
+    let cabinet = (outputCabinet, woodTrapdoor, woodSlab) => {
+        event.remove({ output: outputCabinet })
+        event.shaped(outputCabinet, [
+            'SCS',
+            'TDT',
+            'SCS'
+        ],{
+            S: woodSlab,
+            T: woodTrapdoor,
+            C: 'gtceu:iron_screw',
+            D: '#forge:tools/screwdrivers'
+        })
+    }
+//Actually using the function
+    cabinet('farmersdelight:oak_cabinet', 'minecraft:oak_trapdoor', 'minecraft:oak_slab')
+    cabinet('farmersdelight:spruce_cabinet', 'minecraft:spruce_trapdoor', 'minecraft:spruce_slab')
+    cabinet('farmersdelight:birch_cabinet', 'minecraft:birch_trapdoor', 'minecraft:birch_slab')
+    cabinet('farmersdelight:jungle_cabinet', 'minecraft:jungle_trapdoor', 'minecraft:jungle_slab')
+    cabinet('farmersdelight:acacia_cabinet', 'minecraft:acacia_trapdoor', 'minecraft:acacia_slab')
+    cabinet('farmersdelight:dark_oak_cabinet', 'minecraft:dark_oak_trapdoor', 'minecraft:dark_oak_slab')
+    cabinet('farmersdelight:mangrove_cabinet', 'minecraft:mangrove_trapdoor', 'minecraft:mangrove_slab')
+    cabinet('farmersdelight:cherry_cabinet', 'minecraft:cherry_trapdoor', 'minecraft:cherry_slab')
+    cabinet('farmersdelight:bamboo_cabinet', 'minecraft:bamboo_trapdoor', 'minecraft:bamboo_slab')
+    cabinet('farmersdelight:crimson_cabinet', 'minecraft:crimson_trapdoor', 'minecraft:crimson_slab')
+    cabinet('farmersdelight:warped_cabinet', 'minecraft:warped_trapdoor', 'minecraft:warped_slab')
+
+//Non Wood Cabinets getting Gregified
+    event.remove({ output:'delightful:quartz_cabinet' })
+    event.shaped( 'delightful:quartz_cabinet', [
+        'BHB',
+        'QCQ',
+        'QQQ'
+    ], {
+        B: 'minecraft:polished_blackstone_slab',
+        C: '#farmersdelight:cabinets/wooden',
+        H: '#forge:tools/hammers',
+        Q: 'gtceu:nether_quartz_plate'
+    })
+    event.remove({ output:'delightful:basalt_cabinet' })
+    event.shaped( 'delightful:basalt_cabinet', [
+        'BHB',
+        'SCS',
+        'SSS'
+    ], {
+        B: 'minecraft:polished_blackstone_slab',
+        C: '#farmersdelight:cabinets/wooden',
+        H: '#forge:tools/hammers',
+        S: 'minecraft:basalt' 
+    })
+})
+
+//Machetes, but... uh... oh yeah! Gregified
+ServerEvents.recipes(event => {
+    event.remove({ output:'#forge:tools/machetes' })
+    event.shaped( 'nethersdelight:iron_machete', [
+        '  I',
+        'FI ',
+        'SH '
+    ],{
+        I: 'gtceu:iron_plate',
+        F: '#forge:tools/files',
+        H: '#forge:tools/hammers',
+        S: 'minecraft:stick'
+    })
+    event.shaped( 'nethersdelight:golden_machete', [
+        '  G',
+        'FG ',
+        'SH '
+    ],{
+        G: 'gtceu:gold_plate',
+        F: '#forge:tools/files',
+        H: '#forge:tools/hammers',
+        S: 'minecraft:stick'
+    })
+    event.shaped( 'nethersdelight:diamond_machete', [
+        '  D',
+        'FD ',
+        'SH '
+    ],{
+        D: 'gtceu:diamond_plate',
+        F: '#forge:tools/files',
+        H: '#forge:tools/hammers',
+        S: 'minecraft:stick'
+    })
+    event.smithing(
+        'nethersdelight:netherite_machete',
+        'minecraft:netherite_upgrade_smithing_template',
+        'nethersdelight:diamond_machete',
+        'minecraft:netherite_ingot'
+    )
+})
+
+//Gregifying misc recipes
+ServerEvents.recipes(event => {
+    event.remove({ id:'farmersdelight:canvas' })
+    event.recipes.gtceu.compressor('gtceu:canvas_compress')
+       .itemInputs('4x farmersdelight:straw')
+       .itemOutputs('farmersdelight:canvas')
+       .duration(5)
+       .EUt(8)     
+})
+
+//Removing some recipes that have a GT alternative
+ServerEvents.recipes(event => {
+    event.remove({ id:'farmersdelight:paper_from_tree_bark' })
+    event.remove({ id:'farmersdelight:painting_from_canvas' })
+    event.remove({ id:'farmersdelight:book_from_canvas' })
+})


### PR DESCRIPTION
![image](https://github.com/Ghostipedia/CosmicFrontiers/assets/99605300/3df984b7-ed4b-446b-89e2-83621e625688)
An example recipe would be like this.
Almost all recipes have been modified to use GTCEU parts and tools.
The Blackstone smoker and blast furnace have not been touched due to the vanilla counterparts being also untouched.